### PR TITLE
Prepare for release 10.5.8-v23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	kmodules.xyz/client-go v0.29.6
 	kmodules.xyz/custom-resources v0.29.1
 	kmodules.xyz/offshoot-api v0.29.0
-	stash.appscode.dev/apimachinery v0.32.1-0.20240209175028-1fb8e3376f2c
+	stash.appscode.dev/apimachinery v0.33.0-rc.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -564,5 +564,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+s
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
-stash.appscode.dev/apimachinery v0.32.1-0.20240209175028-1fb8e3376f2c h1:swyyQ3GXY7/DkOCCPe9s8FO4+g8/D47eCwDZyOyAOC0=
-stash.appscode.dev/apimachinery v0.32.1-0.20240209175028-1fb8e3376f2c/go.mod h1:E+mbh2FR1oKyP7WQS5W3MzOrZ3iZUSvrzSCCJPa8qRc=
+stash.appscode.dev/apimachinery v0.33.0-rc.0 h1:yfLn3YYgfo12pTI8oOZBswkQpzFt4MzPaIaoZ2Nok64=
+stash.appscode.dev/apimachinery v0.33.0-rc.0/go.mod h1:M51wIqUONZ7cmx/h5W+Lp+/TlYAF8z7+kQJPsvtl7G4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -790,8 +790,8 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# stash.appscode.dev/apimachinery v0.32.1-0.20240209175028-1fb8e3376f2c
-## explicit; go 1.21.6
+# stash.appscode.dev/apimachinery v0.33.0-rc.0
+## explicit; go 1.21.5
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories
 stash.appscode.dev/apimachinery/apis/repositories/v1alpha1


### PR DESCRIPTION
ProductLine: Stash
Release: v2024.2.9-rc.0
Release-tracker: https://github.com/stashed/CHANGELOG/pull/70
Signed-off-by: 1gtm <1gtm@appscode.com>